### PR TITLE
Use cookie redirect method in forms to redirect to the service start page

### DIFF
--- a/src/lib/middleware.ts
+++ b/src/lib/middleware.ts
@@ -1,4 +1,8 @@
-import { GetServerSideProps, GetServerSidePropsContext } from "next";
+import {
+  GetServerSideProps,
+  GetServerSidePropsContext,
+  GetServerSidePropsResult,
+} from "next";
 import { NextApiRequestCookies } from "next/dist/next-server/server/api-utils";
 import { BeaconCacheEntry, FormCacheFactory, IFormCache } from "./formCache";
 import { v4 as uuidv4 } from "uuid";
@@ -8,22 +12,24 @@ import { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "http";
 import parse from "urlencoded-body-parser";
 import { toArray } from "./utils";
 
-export const withCookieRedirect = (callback: GetServerSideProps) => async (
-  context: GetServerSidePropsContext
-) => {
-  const cookies: NextApiRequestCookies = context.req.cookies;
+export function withCookieRedirect<T>(callback: GetServerSideProps<T>) {
+  return async (
+    context: GetServerSidePropsContext
+  ): Promise<GetServerSidePropsResult<T>> => {
+    const cookies: NextApiRequestCookies = context.req.cookies;
 
-  if (!cookies || !cookies[formSubmissionCookieId]) {
-    return {
-      redirect: {
-        destination: "/",
-        permanent: false,
-      },
-    };
-  }
+    if (!cookies || !cookies[formSubmissionCookieId]) {
+      return {
+        redirect: {
+          destination: "/",
+          permanent: false,
+        },
+      };
+    }
 
-  return callback(context);
-};
+    return callback(context);
+  };
+}
 
 export const setFormSubmissionCookie = (
   context: GetServerSidePropsContext

--- a/src/lib/middleware.ts
+++ b/src/lib/middleware.ts
@@ -1,4 +1,4 @@
-import { GetServerSidePropsContext } from "next";
+import { GetServerSideProps, GetServerSidePropsContext } from "next";
 import { NextApiRequestCookies } from "next/dist/next-server/server/api-utils";
 import { BeaconCacheEntry, FormCacheFactory, IFormCache } from "./formCache";
 import { v4 as uuidv4 } from "uuid";
@@ -8,12 +8,21 @@ import { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "http";
 import parse from "urlencoded-body-parser";
 import { toArray } from "./utils";
 
-export const cookieRedirect = (context: GetServerSidePropsContext): void => {
+export const withCookieRedirect = (callback: GetServerSideProps) => async (
+  context: GetServerSidePropsContext
+) => {
   const cookies: NextApiRequestCookies = context.req.cookies;
 
   if (!cookies || !cookies[formSubmissionCookieId]) {
-    context.res.writeHead(307, { Location: "/" }).end();
+    return {
+      redirect: {
+        destination: "/",
+        permanent: false,
+      },
+    };
   }
+
+  return callback(context);
 };
 
 export const setFormSubmissionCookie = (

--- a/src/pages/register-a-beacon/application-complete.tsx
+++ b/src/pages/register-a-beacon/application-complete.tsx
@@ -1,8 +1,10 @@
+import { GetServerSideProps, GetServerSidePropsContext } from "next";
 import React, { FunctionComponent } from "react";
 import { Grid } from "../../components/Grid";
 import { Layout } from "../../components/Layout";
 import { Panel } from "../../components/Panel";
 import { WarningText } from "../../components/WarningText";
+import { withCookieRedirect } from "../../lib/middleware";
 
 const ApplicationCompletePage: FunctionComponent = () => (
   <>
@@ -44,6 +46,14 @@ const ApplicationCompleteWhatNext: FunctionComponent = () => (
       more information.
     </div>
   </>
+);
+
+export const getServerSideProps: GetServerSideProps = withCookieRedirect(
+  async (context: GetServerSidePropsContext) => {
+    return {
+      props: {},
+    };
+  }
 );
 
 export default ApplicationCompletePage;

--- a/src/pages/register-a-beacon/application-complete.tsx
+++ b/src/pages/register-a-beacon/application-complete.tsx
@@ -1,4 +1,4 @@
-import { GetServerSideProps, GetServerSidePropsContext } from "next";
+import { GetServerSideProps } from "next";
 import React, { FunctionComponent } from "react";
 import { Grid } from "../../components/Grid";
 import { Layout } from "../../components/Layout";
@@ -49,7 +49,7 @@ const ApplicationCompleteWhatNext: FunctionComponent = () => (
 );
 
 export const getServerSideProps: GetServerSideProps = withCookieRedirect(
-  async (context: GetServerSidePropsContext) => {
+  async () => {
     return {
       props: {},
     };

--- a/src/pages/register-a-beacon/beacon-information.tsx
+++ b/src/pages/register-a-beacon/beacon-information.tsx
@@ -20,7 +20,7 @@ import {
   DateListItem,
   DateType,
 } from "../../components/DateInput";
-import { GetServerSideProps, GetServerSidePropsContext } from "next";
+import { GetServerSideProps } from "next";
 import { withCookieRedirect } from "../../lib/middleware";
 
 const BeaconInformationPage: FunctionComponent = () => (
@@ -196,7 +196,7 @@ const BeaconLastServicedDate: FunctionComponent = (): JSX.Element => (
 );
 
 export const getServerSideProps: GetServerSideProps = withCookieRedirect(
-  async (context: GetServerSidePropsContext) => {
+  async () => {
     return {
       props: {},
     };

--- a/src/pages/register-a-beacon/beacon-information.tsx
+++ b/src/pages/register-a-beacon/beacon-information.tsx
@@ -21,6 +21,7 @@ import {
   DateType,
 } from "../../components/DateInput";
 import { GetServerSideProps, GetServerSidePropsContext } from "next";
+import { withCookieRedirect } from "../../lib/middleware";
 
 const BeaconInformationPage: FunctionComponent = () => (
   <>
@@ -194,12 +195,12 @@ const BeaconLastServicedDate: FunctionComponent = (): JSX.Element => (
   </DateListInput>
 );
 
-export const getServerSideProps: GetServerSideProps = async (
-  context: GetServerSidePropsContext
-) => {
-  return {
-    props: {},
-  };
-};
+export const getServerSideProps: GetServerSideProps = withCookieRedirect(
+  async (context: GetServerSidePropsContext) => {
+    return {
+      props: {},
+    };
+  }
+);
 
 export default BeaconInformationPage;

--- a/src/pages/register-a-beacon/check-beacon-details.tsx
+++ b/src/pages/register-a-beacon/check-beacon-details.tsx
@@ -16,7 +16,11 @@ import { Details } from "../../components/Details";
 import { IfYouNeedHelp } from "../../components/Mca";
 import { GetServerSideProps, GetServerSidePropsContext } from "next";
 import { BeaconCacheEntry } from "../../lib/formCache";
-import { getCache, updateFormCache } from "../../lib/middleware";
+import {
+  getCache,
+  updateFormCache,
+  withCookieRedirect,
+} from "../../lib/middleware";
 import { ErrorSummary } from "../../components/ErrorSummary";
 import { FieldValidator } from "../../lib/fieldValidator";
 
@@ -234,47 +238,47 @@ const BeaconHexIdInput: FunctionComponent<FormInputProps> = ({
   </FormGroup>
 );
 
-export const getServerSideProps: GetServerSideProps = async (
-  context: GetServerSidePropsContext
-) => {
-  if (context.req.method === "POST") {
-    const formData: BeaconCacheEntry = await updateFormCache(context);
+export const getServerSideProps: GetServerSideProps = withCookieRedirect(
+  async (context: GetServerSidePropsContext) => {
+    if (context.req.method === "POST") {
+      const formData: BeaconCacheEntry = await updateFormCache(context);
 
-    manufacturerField.value = formData.manufacturer;
-    modelField.value = formData.model;
-    hexIdField.value = formData.hexId;
+      manufacturerField.value = formData.manufacturer;
+      modelField.value = formData.model;
+      hexIdField.value = formData.hexId;
 
-    if (
-      manufacturerField.hasError() ||
-      modelField.hasError() ||
-      hexIdField.hasError()
-    ) {
-      return {
-        props: {
-          needsValidation: true,
-          manufacturer: formData.manufacturer,
-          model: formData.model,
-          hexId: formData.hexId,
-        },
-      };
-    } else {
-      return {
-        redirect: {
-          destination: "/register-a-beacon/beacon-information",
-          permanent: false,
-        },
-      };
+      if (
+        manufacturerField.hasError() ||
+        modelField.hasError() ||
+        hexIdField.hasError()
+      ) {
+        return {
+          props: {
+            needsValidation: true,
+            manufacturer: formData.manufacturer,
+            model: formData.model,
+            hexId: formData.hexId,
+          },
+        };
+      } else {
+        return {
+          redirect: {
+            destination: "/register-a-beacon/beacon-information",
+            permanent: false,
+          },
+        };
+      }
     }
+
+    const formData: BeaconCacheEntry = getCache(context);
+
+    return {
+      props: {
+        needsValidation: false,
+        ...formData,
+      },
+    };
   }
-
-  const formData: BeaconCacheEntry = getCache(context);
-
-  return {
-    props: {
-      needsValidation: false,
-      ...formData,
-    },
-  };
-};
+);
 
 export default CheckBeaconDetails;

--- a/src/pages/register-a-beacon/check-beacon-summary.tsx
+++ b/src/pages/register-a-beacon/check-beacon-summary.tsx
@@ -16,9 +16,9 @@ import {
 import { GetServerSideProps, GetServerSidePropsContext } from "next";
 
 interface BeaconDetailsProps {
-  beaconManufacturer: string;
-  beaconModel: string;
-  beaconHexId: string;
+  manufacturer: string;
+  model: string;
+  hexId: string;
 }
 
 const CheckBeaconSummaryPage: FunctionComponent<BeaconDetailsProps> = (
@@ -59,19 +59,19 @@ const BeaconNotRegisteredView: FunctionComponent<BeaconDetailsProps> = (
 };
 
 const BeaconSummary: FunctionComponent<BeaconDetailsProps> = ({
-  beaconManufacturer,
-  beaconModel,
-  beaconHexId,
+  manufacturer,
+  model,
+  hexId,
 }: BeaconDetailsProps): JSX.Element => (
   <>
     <h1 className="govuk-heading-l">Check beacon summary</h1>
     <SummaryList>
       <SummaryListItem
         labelText="Beacon manufacturer"
-        valueText={beaconManufacturer}
+        valueText={manufacturer}
       />
-      <SummaryListItem labelText="Beacon model" valueText={beaconModel} />
-      <SummaryListItem labelText="Beacon HEX ID" valueText={beaconHexId} />
+      <SummaryListItem labelText="Beacon model" valueText={model} />
+      <SummaryListItem labelText="Beacon HEX ID" valueText={hexId} />
       <SummaryListItem
         labelText="Date registered"
         // TODO: Lookup for date registered if beacon already in system
@@ -84,17 +84,17 @@ const BeaconSummary: FunctionComponent<BeaconDetailsProps> = ({
 export const getServerSideProps: GetServerSideProps = withCookieRedirect(
   async (context: GetServerSidePropsContext) => {
     if (context.req.method === "POST") {
-      const previousFormPageData: BeaconDetailsProps = await updateFormCache(
+      const previousFormPageData: BeaconCacheEntry = await updateFormCache(
         context
       );
 
       return {
-        props: previousFormPageData,
+        props: { ...previousFormPageData },
       };
     } else if (context.req.method === "GET") {
       const existingState: BeaconCacheEntry = getCache(context);
 
-      return { props: existingState };
+      return { props: { ...existingState } };
     }
 
     return {

--- a/src/pages/register-a-beacon/check-beacon-summary.tsx
+++ b/src/pages/register-a-beacon/check-beacon-summary.tsx
@@ -9,7 +9,7 @@ import { NotificationBannerSuccess } from "../../components/NotificationBanner";
 import { BackButton, LinkButton } from "../../components/Button";
 import { IfYouNeedHelp } from "../../components/Mca";
 import {
-  cookieRedirect,
+  withCookieRedirect,
   getCache,
   updateFormCache,
 } from "../../lib/middleware";
@@ -81,28 +81,26 @@ const BeaconSummary: FunctionComponent<BeaconDetailsProps> = ({
   </>
 );
 
-export const getServerSideProps: GetServerSideProps = async (
-  context: GetServerSidePropsContext
-) => {
-  cookieRedirect(context);
+export const getServerSideProps: GetServerSideProps = withCookieRedirect(
+  async (context: GetServerSidePropsContext) => {
+    if (context.req.method === "POST") {
+      const previousFormPageData: BeaconDetailsProps = await updateFormCache(
+        context
+      );
 
-  if (context.req.method === "POST") {
-    const previousFormPageData: BeaconDetailsProps = await updateFormCache(
-      context
-    );
+      return {
+        props: previousFormPageData,
+      };
+    } else if (context.req.method === "GET") {
+      const existingState: BeaconCacheEntry = getCache(context);
+
+      return { props: existingState };
+    }
 
     return {
-      props: previousFormPageData,
+      props: {},
     };
-  } else if (context.req.method === "GET") {
-    const existingState: BeaconCacheEntry = getCache(context);
-
-    return { props: existingState };
   }
-
-  return {
-    props: {},
-  };
-};
+);
 
 export default CheckBeaconSummaryPage;

--- a/src/pages/register-a-beacon/check-your-answers.tsx
+++ b/src/pages/register-a-beacon/check-your-answers.tsx
@@ -6,6 +6,7 @@ import { BackButton, Button } from "../../components/Button";
 import { GetServerSideProps, GetServerSidePropsContext } from "next";
 import { Beacon } from "../../lib/types";
 import { SummaryList, SummaryListItem } from "../../components/SummaryList";
+import { withCookieRedirect } from "../../lib/middleware";
 
 interface CheckYourAnswersProps {
   beacon: Beacon;
@@ -97,26 +98,26 @@ const SendYourApplication: FunctionComponent = (): JSX.Element => (
   </>
 );
 
-export const getServerSideProps: GetServerSideProps = async (
-  context: GetServerSidePropsContext
-) => {
-  // TODO: State persistence stuff to go here
+export const getServerSideProps: GetServerSideProps = withCookieRedirect(
+  async (context: GetServerSidePropsContext) => {
+    // TODO: State persistence stuff to go here
 
-  const fakeBeacon: Beacon = {
-    manufacturer: "Raleigh",
-    model: "Chopper",
-    hexId: "34D17AE391BC3",
-    manufacturerSerialNumber: "PN000123",
-    batteryExpiryDate: "17 November 2024",
-    lastServicedDate: "13 October 2020",
-  };
+    const fakeBeacon: Beacon = {
+      manufacturer: "Raleigh",
+      model: "Chopper",
+      hexId: "34D17AE391BC3",
+      manufacturerSerialNumber: "PN000123",
+      batteryExpiryDate: "17 November 2024",
+      lastServicedDate: "13 October 2020",
+    };
 
-  // Temporary, to make linting warning go away
-  context;
+    // Temporary, to make linting warning go away
+    context;
 
-  return {
-    props: { beacon: fakeBeacon },
-  };
-};
+    return {
+      props: { beacon: fakeBeacon },
+    };
+  }
+);
 
 export default CheckYourAnswersPage;

--- a/src/pages/register-a-beacon/check-your-answers.tsx
+++ b/src/pages/register-a-beacon/check-your-answers.tsx
@@ -3,7 +3,7 @@ import { Grid } from "../../components/Grid";
 import { Layout } from "../../components/Layout";
 import { GovUKBody, PageHeading } from "../../components/Typography";
 import { BackButton, Button } from "../../components/Button";
-import { GetServerSideProps, GetServerSidePropsContext } from "next";
+import { GetServerSideProps } from "next";
 import { Beacon } from "../../lib/types";
 import { SummaryList, SummaryListItem } from "../../components/SummaryList";
 import { withCookieRedirect } from "../../lib/middleware";
@@ -99,7 +99,7 @@ const SendYourApplication: FunctionComponent = (): JSX.Element => (
 );
 
 export const getServerSideProps: GetServerSideProps = withCookieRedirect(
-  async (context: GetServerSidePropsContext) => {
+  async () => {
     // TODO: State persistence stuff to go here
 
     const fakeBeacon: Beacon = {
@@ -110,9 +110,6 @@ export const getServerSideProps: GetServerSideProps = withCookieRedirect(
       batteryExpiryDate: "17 November 2024",
       lastServicedDate: "13 October 2020",
     };
-
-    // Temporary, to make linting warning go away
-    context;
 
     return {
       props: { beacon: fakeBeacon },


### PR DESCRIPTION
## Context

- When a user does not have an active session, they must be redirected to the service start page 

## Changes in this pull request

- Update the `cookieRedirect` function, by: renaming to `withCookieRedirect`, replace the existing `getServerSideProps` functions to use this to ensure a user is redirected to the service start page if they do not have an active session


## Things to check

- User is redirected to the service start page if they do not have an active session
