### PR TITLE
WIP Form validation 2.0

### DIFF
--- a/src/lib/fieldValidator.ts
+++ b/src/lib/fieldValidator.ts
@@ -5,52 +5,30 @@ import {
 } from "./validatorFunctions";
 
 export interface IFieldValidator {
-  value: string;
-  id: string;
-  hasError(): boolean;
-  errorMessages(): string[];
+  validate(value: string): boolean;
+  errorMessages(value: string): string[];
 }
 
-interface FieldRule {
+export interface IFieldRule {
   validatorFunction: ValidatorFunction;
   errorMessage: string;
 }
 
 export class FieldValidator implements IFieldValidator {
-  private _id: string;
-  private _value: string;
-  private _rules: FieldRule[];
+  private _rules: IFieldRule[];
 
-  constructor(fieldId: string) {
-    this._id = fieldId;
-    this._rules = [];
-    this._value = "";
+  constructor(...rules: IFieldRule[]) {
+    this._rules = rules;
   }
 
-  public get value(): string {
-    return this._value;
+  public validate(value: string): boolean {
+    if (this._rules.length === 0) return true;
+    return this._rules.some((rule) => !rule.validatorFunction(value));
   }
 
-  public set value(value: string) {
-    this._value = value;
-  }
-
-  public get id(): string {
-    return this._id;
-  }
-
-  public hasError(): boolean {
-    if (this._rules.length >= 1) {
-      return this._rules
-        .map((rule) => rule.validatorFunction(this.value))
-        .includes(true);
-    }
-    return false;
-  }
-
-  public errorMessages(): string[] {
+  public errorMessages(value: string): string[] {
     return this._rules
-      .filter((rule) => rule.validatorFunction(this.value))
+      .filter((rule) => rule.validatorFunction(value))
       .map((rule) => rule.errorMessage);
   }
 

--- a/src/lib/fieldValidator.ts
+++ b/src/lib/fieldValidator.ts
@@ -24,6 +24,7 @@ export class FieldValidator implements IFieldValidator {
   constructor(fieldId: string) {
     this._id = fieldId;
     this._rules = [];
+    this._value = "";
   }
 
   public get value(): string {

--- a/src/lib/fieldValidator.ts
+++ b/src/lib/fieldValidator.ts
@@ -26,19 +26,19 @@ export class FieldValidator implements IFieldValidator {
     this._rules = [];
   }
 
-  get value(): string {
+  public get value(): string {
     return this._value;
   }
 
-  set value(value: string) {
+  public set value(value: string) {
     this._value = value;
   }
 
-  get fieldId(): string {
+  public get fieldId(): string {
     return this._fieldId;
   }
 
-  hasError(): boolean {
+  public hasError(): boolean {
     if (this._rules.length >= 1) {
       return this._rules
         .map((rule) => rule.validatorFunction(this.value))
@@ -47,18 +47,18 @@ export class FieldValidator implements IFieldValidator {
     return false;
   }
 
-  errorMessages(): string[] {
+  public errorMessages(): string[] {
     return this._rules
       .filter((rule) => rule.validatorFunction(this.value))
       .map((rule) => rule.errorMessage);
   }
 
   // Declarative matcher-type syntax starts here -- possibly extract?
-  should(): FieldValidator {
+  public should(): FieldValidator {
     return this;
   }
 
-  containANonEmptyString(): FieldValidator {
+  public containANonEmptyString(): FieldValidator {
     const rule = {
       validatorFunction: emptyRequiredField,
       errorMessage: "",
@@ -67,7 +67,7 @@ export class FieldValidator implements IFieldValidator {
     return this;
   }
 
-  beExactly15Characters(): FieldValidator {
+  public beExactly15Characters(): FieldValidator {
     const rule = {
       validatorFunction: isNot15CharactersLong,
       errorMessage: "",
@@ -76,7 +76,7 @@ export class FieldValidator implements IFieldValidator {
     return this;
   }
 
-  withErrorMessage(message: string): FieldValidator {
+  public withErrorMessage(message: string): FieldValidator {
     this._rules[this._rules.length - 1].errorMessage = message;
     return this;
   }

--- a/src/lib/fieldValidator.ts
+++ b/src/lib/fieldValidator.ts
@@ -6,7 +6,7 @@ import {
 
 export interface IFieldValidator {
   value: string;
-  fieldId: string;
+  id: string;
   hasError(): boolean;
   errorMessages(): string[];
 }
@@ -17,12 +17,12 @@ interface FieldRule {
 }
 
 export class FieldValidator implements IFieldValidator {
-  private _fieldId: string;
+  private _id: string;
   private _value: string;
   private _rules: FieldRule[];
 
   constructor(fieldId: string) {
-    this._fieldId = fieldId;
+    this._id = fieldId;
     this._rules = [];
   }
 
@@ -34,8 +34,8 @@ export class FieldValidator implements IFieldValidator {
     this._value = value;
   }
 
-  public get fieldId(): string {
-    return this._fieldId;
+  public get id(): string {
+    return this._id;
   }
 
   public hasError(): boolean {

--- a/src/lib/fieldValidator.ts
+++ b/src/lib/fieldValidator.ts
@@ -4,12 +4,19 @@ import {
   isNot15CharactersLong,
 } from "./validatorFunctions";
 
+export interface IFieldValidator {
+  value: string;
+  fieldId: string;
+  hasError(): boolean;
+  errorMessages(): string[];
+}
+
 interface FieldRule {
   validatorFunction: ValidatorFunction;
   errorMessage: string;
 }
 
-export class FieldValidator {
+export class FieldValidator implements IFieldValidator {
   private _fieldId: string;
   private _value: string;
   private _rules: FieldRule[];

--- a/src/lib/formValidator.ts
+++ b/src/lib/formValidator.ts
@@ -20,4 +20,10 @@ export class FormValidator {
 
     return requestedField;
   }
+
+  public updateValues(newValues: Record<string, string>): void {
+    Object.keys(newValues).forEach((fieldId) => {
+      this.field(fieldId).value = newValues[fieldId];
+    });
+  }
 }

--- a/src/lib/formValidator.ts
+++ b/src/lib/formValidator.ts
@@ -1,0 +1,19 @@
+import { FieldValidator } from "./fieldValidator";
+
+export class FormValidator {
+  private _fields: FieldValidator[];
+
+  constructor(...fields: FieldValidator[]) {
+    this._fields = fields;
+  }
+
+  hasError(): boolean {
+    return this._fields.some((field) => {
+      return field.hasError();
+    });
+  }
+
+  getField(fieldId: string): FieldValidator {
+    return this._fields.find((field) => field.fieldId === fieldId);
+  }
+}

--- a/src/lib/formValidator.ts
+++ b/src/lib/formValidator.ts
@@ -13,6 +13,10 @@ export class FormValidator {
     });
   }
 
+  public isValid(): boolean {
+    return !this.hasError();
+  }
+
   public field(fieldId: string): IFieldValidator {
     const requestedField = this._fields.find((field) => field.id === fieldId);
     if (requestedField === undefined)

--- a/src/lib/formValidator.ts
+++ b/src/lib/formValidator.ts
@@ -7,13 +7,19 @@ export class FormValidator {
     this._fields = fields;
   }
 
-  hasError(): boolean {
+  public hasError(): boolean {
     return this._fields.some((field) => {
       return field.hasError();
     });
   }
 
-  getField(fieldId: string): IFieldValidator {
-    return this._fields.find((field) => field.fieldId === fieldId);
+  public field(fieldId: string): IFieldValidator {
+    const requestedField = this._fields.find(
+      (field) => field.fieldId === fieldId
+    );
+    if (requestedField === undefined)
+      throw new ReferenceError("Field does not exist in form");
+
+    return requestedField;
   }
 }

--- a/src/lib/formValidator.ts
+++ b/src/lib/formValidator.ts
@@ -1,5 +1,10 @@
 import { IFieldValidator } from "./fieldValidator";
 
+export interface FormErrors {
+  linkedFieldId: string;
+  messages: string[];
+}
+
 export class FormValidator {
   private _fields: IFieldValidator[];
 
@@ -29,5 +34,16 @@ export class FormValidator {
     Object.keys(newValues).forEach((fieldId) => {
       this.field(fieldId).value = newValues[fieldId];
     });
+  }
+
+  public errors(): FormErrors[] {
+    return this._fields
+      .filter((field) => field.hasError())
+      .map((fieldWithError) => {
+        return {
+          linkedFieldId: fieldWithError.id,
+          messages: fieldWithError.errorMessages(),
+        };
+      });
   }
 }

--- a/src/lib/formValidator.ts
+++ b/src/lib/formValidator.ts
@@ -1,9 +1,9 @@
-import { FieldValidator } from "./fieldValidator";
+import { IFieldValidator } from "./fieldValidator";
 
 export class FormValidator {
-  private _fields: FieldValidator[];
+  private _fields: IFieldValidator[];
 
-  constructor(...fields: FieldValidator[]) {
+  constructor(...fields: IFieldValidator[]) {
     this._fields = fields;
   }
 
@@ -13,7 +13,7 @@ export class FormValidator {
     });
   }
 
-  getField(fieldId: string): FieldValidator {
+  getField(fieldId: string): IFieldValidator {
     return this._fields.find((field) => field.fieldId === fieldId);
   }
 }

--- a/src/lib/formValidator.ts
+++ b/src/lib/formValidator.ts
@@ -14,9 +14,7 @@ export class FormValidator {
   }
 
   public field(fieldId: string): IFieldValidator {
-    const requestedField = this._fields.find(
-      (field) => field.fieldId === fieldId
-    );
+    const requestedField = this._fields.find((field) => field.id === fieldId);
     if (requestedField === undefined)
       throw new ReferenceError("Field does not exist in form");
 

--- a/src/pages/register-a-beacon/check-beacon-details.tsx
+++ b/src/pages/register-a-beacon/check-beacon-details.tsx
@@ -83,14 +83,11 @@ const CheckBeaconDetails: FunctionComponent<CheckBeaconDetailsProps> = ({
         <Grid
           mainContent={
             <>
-              {needsValidation &&
-                (manufacturerField.hasError() ||
-                  modelField.hasError() ||
-                  hexIdField.hasError()) && (
-                  <ErrorSummaryComponent
-                    validators={[manufacturerField, modelField, hexIdField]}
-                  />
-                )}
+              {needsValidation && form.hasError() && (
+                <ErrorSummaryComponent
+                  validators={[manufacturerField, modelField, hexIdField]}
+                />
+              )}
               <Form action="/register-a-beacon/check-beacon-details">
                 <FormFieldset>
                   <FormLegendPageHeading>
@@ -103,21 +100,23 @@ const CheckBeaconDetails: FunctionComponent<CheckBeaconDetailsProps> = ({
                   </InsetText>
 
                   <BeaconManufacturerInput
-                    value={manufacturer}
-                    isError={needsValidation && manufacturerField.hasError()}
-                    errorMessages={manufacturerField.errorMessages()}
+                    value={form.field("manufacturer").value}
+                    isError={
+                      needsValidation && form.field("manufacturer").hasError()
+                    }
+                    errorMessages={form.field("manufacturer").errorMessages()}
                   />
 
                   <BeaconModelInput
-                    value={model}
-                    isError={needsValidation && modelField.hasError()}
-                    errorMessages={modelField.errorMessages()}
+                    value={form.field("model").value}
+                    isError={needsValidation && form.field("model").hasError()}
+                    errorMessages={form.field("model").errorMessages()}
                   />
 
                   <BeaconHexIdInput
-                    value={hexId}
-                    isError={needsValidation && hexIdField.hasError()}
-                    errorMessages={hexIdField.errorMessages()}
+                    value={form.field("hexId").value}
+                    isError={needsValidation && form.field("hexId").hasError()}
+                    errorMessages={form.field("hexId").errorMessages()}
                   />
                 </FormFieldset>
                 <Button buttonText="Submit" />
@@ -242,9 +241,9 @@ export const getServerSideProps: GetServerSideProps = withCookieRedirect(
     const formData: BeaconCacheEntry = await updateFormCache(context);
     form.updateValues(formData);
 
-    const userSubmittedForm = context.req.method === "POST";
+    const userDidSubmitForm = context.req.method === "POST";
 
-    if (userSubmittedForm && form.isValid()) {
+    if (userDidSubmitForm && form.isValid()) {
       return {
         redirect: {
           destination: "/register-a-beacon/beacon-information",
@@ -255,10 +254,11 @@ export const getServerSideProps: GetServerSideProps = withCookieRedirect(
 
     return {
       props: {
-        needsValidation: userSubmittedForm,
-        manufacturer: manufacturerField.value,
-        model: modelField.value,
-        hexId: hexIdField.value,
+        needsValidation: userDidSubmitForm,
+        // TODO, remove once page component no longer relies on them
+        manufacturer: form.field("manufacturer").value,
+        model: form.field("model").value,
+        hexId: form.field("hexId").value,
       },
     };
   }

--- a/src/pages/register-a-beacon/check-beacon-details.tsx
+++ b/src/pages/register-a-beacon/check-beacon-details.tsx
@@ -16,11 +16,7 @@ import { Details } from "../../components/Details";
 import { IfYouNeedHelp } from "../../components/Mca";
 import { GetServerSideProps, GetServerSidePropsContext } from "next";
 import { BeaconCacheEntry } from "../../lib/formCache";
-import {
-  getCache,
-  updateFormCache,
-  withCookieRedirect,
-} from "../../lib/middleware";
+import { updateFormCache, withCookieRedirect } from "../../lib/middleware";
 import { ErrorSummary } from "../../components/ErrorSummary";
 import { FieldValidator } from "../../lib/fieldValidator";
 
@@ -240,42 +236,35 @@ const BeaconHexIdInput: FunctionComponent<FormInputProps> = ({
 
 export const getServerSideProps: GetServerSideProps = withCookieRedirect(
   async (context: GetServerSidePropsContext) => {
-    if (context.req.method === "POST") {
-      const formData: BeaconCacheEntry = await updateFormCache(context);
+    const formData: BeaconCacheEntry = await updateFormCache(context);
 
-      manufacturerField.value = formData.manufacturer;
-      modelField.value = formData.model;
-      hexIdField.value = formData.hexId;
+    manufacturerField.value = formData.manufacturer || "";
+    modelField.value = formData.model || "";
+    hexIdField.value = formData.hexId || "";
 
-      if (
-        manufacturerField.hasError() ||
-        modelField.hasError() ||
-        hexIdField.hasError()
-      ) {
-        return {
-          props: {
-            needsValidation: true,
-            manufacturer: formData.manufacturer,
-            model: formData.model,
-            hexId: formData.hexId,
-          },
-        };
-      } else {
-        return {
-          redirect: {
-            destination: "/register-a-beacon/beacon-information",
-            permanent: false,
-          },
-        };
-      }
+    const userSubmittedForm = context.req.method === "POST";
+
+    const formIsValid = !(
+      manufacturerField.hasError() ||
+      modelField.hasError() ||
+      hexIdField.hasError()
+    );
+
+    if (userSubmittedForm && formIsValid) {
+      return {
+        redirect: {
+          destination: "/register-a-beacon/beacon-information",
+          permanent: false,
+        },
+      };
     }
-
-    const formData: BeaconCacheEntry = getCache(context);
 
     return {
       props: {
-        needsValidation: false,
-        ...formData,
+        needsValidation: userSubmittedForm,
+        manufacturer: manufacturerField.value,
+        model: modelField.value,
+        hexId: hexIdField.value,
       },
     };
   }

--- a/test/lib/fieldValidator.test.ts
+++ b/test/lib/fieldValidator.test.ts
@@ -44,7 +44,7 @@ describe("FieldValidator", () => {
       expect(hasError).toBe(true);
     });
 
-    it("should return the error message if field is empty", () => {
+    it("should return the error messages if field is empty", () => {
       const fieldWithValidator = new FieldValidator("formFieldId");
       const errorMessage = "Enter something";
       fieldWithValidator

--- a/test/lib/fieldValidator.test.ts
+++ b/test/lib/fieldValidator.test.ts
@@ -1,71 +1,48 @@
 import { FieldValidator } from "../../src/lib/fieldValidator";
 
 describe("FieldValidator", () => {
-  describe("constructor", () => {
-    it("defaults the value to an empty string, not undefined", () => {
-      const fieldValidator = new FieldValidator("emptyFormField");
+  describe("validate()", () => {
+    it("when given a valid string should return true", () => {
+      const field = new FieldValidator();
+      field.should().containANonEmptyString();
 
-      expect(fieldValidator.value).toBe("");
+      const valid = field.validate("valid string");
+
+      expect(valid).toBe(true);
+    });
+
+    it("when given an invalid string should return false", () => {
+      const field = new FieldValidator();
+      field.should().containANonEmptyString();
+
+      const valid = field.validate("");
+
+      expect(valid).toBe(false);
+    });
+
+    it("when no conditions are set should still return true", () => {
+      const field = new FieldValidator();
+
+      const valid = field.validate("string with no conditions attached");
+
+      expect(valid).toBe(true);
     });
   });
-  describe("hasError()", () => {
-    it("should return false if no value is set", () => {
-      const fieldWithNoValue = new FieldValidator("formFieldId");
 
-      const hasError = fieldWithNoValue.hasError();
-
-      expect(hasError).toBe(false);
-    });
-
-    it("should return false if no validators are added", () => {
-      const fieldWithNoValidators = new FieldValidator("formFieldId");
-      fieldWithNoValidators.value = "field value";
-
-      const hasError = fieldWithNoValidators.hasError();
-
-      expect(hasError).toBe(false);
-    });
-
-    it("should return false if no validators are added", () => {
-      const fieldWithNoValidators = new FieldValidator("formFieldId");
-      fieldWithNoValidators.value = "field value";
-
-      const hasError = fieldWithNoValidators.hasError();
-
-      expect(hasError).toBe(false);
-    });
-
-    it("should return true if field is empty", () => {
-      const fieldWithValidator = new FieldValidator("formFieldId");
-      fieldWithValidator.should().containANonEmptyString();
-
-      const hasError = fieldWithValidator.hasError();
-
-      expect(hasError).toBe(true);
-    });
-
-    it("should return the error messages if field is empty", () => {
-      const fieldWithValidator = new FieldValidator("formFieldId");
-      const errorMessage = "Enter something";
-      fieldWithValidator
+  describe("errorMessages()", () => {
+    it("when string is too long returns a suitable error message", () => {
+      const suitableErrorMessage = "Field should be exactly 15 characters";
+      const field = new FieldValidator();
+      field
         .should()
-        .containANonEmptyString()
-        .withErrorMessage(errorMessage);
+        .beExactly15Characters()
+        .withErrorMessage("Field should be exactly 15 characters");
 
-      const errorMessages = fieldWithValidator.errorMessages();
+      const errorMessages = field.errorMessages(
+        "String less than 15 characters"
+      );
 
-      expect(errorMessages).toStrictEqual([errorMessage]);
-    });
-
-    it("should return false when its only validator function says the field is valid", () => {
-      const value = "This is a valid form field input value";
-      const fieldShouldContainText = new FieldValidator("formFieldId");
-      fieldShouldContainText.should().containANonEmptyString();
-      fieldShouldContainText.value = value;
-
-      const hasError = fieldShouldContainText.hasError();
-
-      expect(hasError).toBe(false);
+      expect(errorMessages).toEqual([suitableErrorMessage]);
     });
   });
 });

--- a/test/lib/fieldValidator.test.ts
+++ b/test/lib/fieldValidator.test.ts
@@ -1,6 +1,13 @@
 import { FieldValidator } from "../../src/lib/fieldValidator";
 
 describe("FieldValidator", () => {
+  describe("constructor", () => {
+    it("defaults the value to an empty string, not undefined", () => {
+      const fieldValidator = new FieldValidator("emptyFormField");
+
+      expect(fieldValidator.value).toBe("");
+    });
+  });
   describe("hasError()", () => {
     it("should return false if no value is set", () => {
       const fieldWithNoValue = new FieldValidator("formFieldId");

--- a/test/lib/formValidator.test.ts
+++ b/test/lib/formValidator.test.ts
@@ -71,4 +71,35 @@ describe("FormValidator", () => {
       expect(hasError).toBe(true);
     });
   });
+
+  describe("field()", () => {
+    it("retrieves a constituent FieldValidator object", () => {
+      const mockFieldValidator1 = createMockFieldValidator("fieldOne", false);
+      const mockFieldValidator2 = createMockFieldValidator("fieldTwo", false);
+      const formValidator = new FormValidator(
+        mockFieldValidator1,
+        mockFieldValidator2
+      );
+
+      const firstField = formValidator.field("fieldOne");
+      const secondField = formValidator.field("fieldTwo");
+
+      expect(firstField).toBe(mockFieldValidator1);
+      expect(secondField).toBe(mockFieldValidator2);
+    });
+
+    it("raises an exception if a non-existent FieldValidator is requested", () => {
+      const mockFieldValidator1 = createMockFieldValidator("fieldOne", false);
+      const mockFieldValidator2 = createMockFieldValidator("fieldTwo", false);
+      const formValidator = new FormValidator(
+        mockFieldValidator1,
+        mockFieldValidator2
+      );
+
+      const requestNonExistentFieldValidator = () =>
+        formValidator.field("doesNotExist");
+
+      expect(requestNonExistentFieldValidator).toThrow(ReferenceError);
+    });
+  });
 });

--- a/test/lib/formValidator.test.ts
+++ b/test/lib/formValidator.test.ts
@@ -1,5 +1,5 @@
 import { FormValidator } from "../../src/lib/formValidator";
-import { FieldValidator } from "../../src/lib/fieldValidator";
+import { FieldValidator } from "../../src/lib/fieldValidator"; // Imported only for Jest auto-mocking
 
 describe("FormValidator", () => {
   const createMockFieldValidator = (fieldId, hasError, initialValue = "") => {
@@ -203,6 +203,30 @@ describe("FormValidator", () => {
         formValidator.updateValues(newValues);
 
       expect(attemptToUpdateWithInvalidValues).toThrowError(ReferenceError);
+    });
+  });
+
+  describe("errors()", () => {
+    it("returns an array of FormErrors", () => {
+      const idOfFormElementWithError = "htmlIdRenderedInDOM";
+      const mockFieldValidatorWithError = createMockFieldValidator(
+        idOfFormElementWithError,
+        true
+      );
+      mockFieldValidatorWithError.errorMessages = jest
+        .fn()
+        .mockReturnValue(["Test error messages"]);
+
+      const formValidator = new FormValidator(mockFieldValidatorWithError);
+
+      const errors = formValidator.errors();
+
+      expect(errors).toEqual([
+        {
+          linkedFieldId: idOfFormElementWithError,
+          messages: ["Test error messages"],
+        },
+      ]);
     });
   });
 });

--- a/test/lib/formValidator.test.ts
+++ b/test/lib/formValidator.test.ts
@@ -2,17 +2,16 @@ import { FormValidator } from "../../src/lib/formValidator";
 import { FieldValidator } from "../../src/lib/fieldValidator";
 
 describe("FormValidator", () => {
+  const createMockFieldValidator = (fieldId, hasError) => {
+    jest.mock("../../src/lib/fieldValidator");
+
+    const fieldValidator = new FieldValidator(fieldId);
+    fieldValidator.hasError = jest.fn().mockReturnValue(hasError);
+
+    return fieldValidator;
+  };
+
   describe("hasError()", () => {
-    const createMockFieldValidator = (fieldId, hasError) => {
-      jest.mock("../../src/lib/fieldValidator");
-
-      const mockHasErrorMethod = jest.fn();
-      mockHasErrorMethod.mockReturnValue(hasError);
-      FieldValidator.prototype.hasError = mockHasErrorMethod;
-
-      return new FieldValidator(fieldId);
-    };
-
     it("should return false if there are no child fields", () => {
       const formWithNoFields = new FormValidator();
 
@@ -41,6 +40,31 @@ describe("FormValidator", () => {
       );
 
       const formWithOneField = new FormValidator(mockFieldValidatorWithError);
+
+      const hasError = formWithOneField.hasError();
+
+      expect(hasError).toBe(true);
+    });
+
+    it("should return true if more than one of the child fields contain an error", () => {
+      const mockFieldValidatorWithError1 = createMockFieldValidator(
+        "fieldWithOneError1",
+        true
+      );
+      const mockFieldValidatorWithError2 = createMockFieldValidator(
+        "fieldWithOneError2",
+        true
+      );
+      const mockFieldValidatorWithNoError = createMockFieldValidator(
+        "fieldWithNoError",
+        false
+      );
+
+      const formWithOneField = new FormValidator(
+        mockFieldValidatorWithError1,
+        mockFieldValidatorWithError2,
+        mockFieldValidatorWithNoError
+      );
 
       const hasError = formWithOneField.hasError();
 

--- a/test/lib/formValidator.test.ts
+++ b/test/lib/formValidator.test.ts
@@ -1,0 +1,32 @@
+import { FormValidator } from "../../src/lib/formValidator";
+import { FieldValidator } from "../../src/lib/fieldValidator";
+
+describe("FormValidator", () => {
+  describe("hasError()", () => {
+    beforeEach(() => {
+      jest.mock("../../src/lib/fieldValidator");
+    });
+
+    it("should return false if there are no child fields", () => {
+      const formWithNoFields = new FormValidator();
+
+      const hasError = formWithNoFields.hasError();
+
+      expect(hasError).toBe(false);
+    });
+
+    it("should return false if none of the child fields contain an error", () => {
+      const mockHasError = jest.fn();
+      mockHasError.mockReturnValue(false);
+      FieldValidator.prototype.hasError = mockHasError;
+
+      const stubFieldWithNoError = new FieldValidator("fieldWithNoErrorId");
+
+      const formWithOneField = new FormValidator(stubFieldWithNoError);
+
+      const hasError = formWithOneField.hasError();
+
+      expect(hasError).toBe(false);
+    });
+  });
+});

--- a/test/lib/formValidator.test.ts
+++ b/test/lib/formValidator.test.ts
@@ -3,9 +3,15 @@ import { FieldValidator } from "../../src/lib/fieldValidator";
 
 describe("FormValidator", () => {
   describe("hasError()", () => {
-    beforeEach(() => {
+    const createMockFieldValidator = (fieldId, hasError) => {
       jest.mock("../../src/lib/fieldValidator");
-    });
+
+      const mockHasErrorMethod = jest.fn();
+      mockHasErrorMethod.mockReturnValue(hasError);
+      FieldValidator.prototype.hasError = mockHasErrorMethod;
+
+      return new FieldValidator(fieldId);
+    };
 
     it("should return false if there are no child fields", () => {
       const formWithNoFields = new FormValidator();
@@ -16,17 +22,29 @@ describe("FormValidator", () => {
     });
 
     it("should return false if none of the child fields contain an error", () => {
-      const mockHasError = jest.fn();
-      mockHasError.mockReturnValue(false);
-      FieldValidator.prototype.hasError = mockHasError;
+      const mockFieldValidatorWithNoError = createMockFieldValidator(
+        "fieldWithNoError",
+        false
+      );
 
-      const stubFieldWithNoError = new FieldValidator("fieldWithNoErrorId");
-
-      const formWithOneField = new FormValidator(stubFieldWithNoError);
+      const formWithOneField = new FormValidator(mockFieldValidatorWithNoError);
 
       const hasError = formWithOneField.hasError();
 
       expect(hasError).toBe(false);
+    });
+
+    it("should return true if one of the child fields contain an error", () => {
+      const mockFieldValidatorWithError = createMockFieldValidator(
+        "fieldWithOneError",
+        true
+      );
+
+      const formWithOneField = new FormValidator(mockFieldValidatorWithError);
+
+      const hasError = formWithOneField.hasError();
+
+      expect(hasError).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Context

We've created a rudimentary `FieldValidator` solution for validating form fields in `check-beacon-details.tsx`.  There is some coupling/duplication we need to reduce and we need to make the boundaries of form validation better defined so classes can be re-used easily.  Specifically:

- The current solution requires creating new `FieldValidators` in global scope.
- Validation takes place twice:  once in `getServerSideProps()` and again in the page FunctionComponent, with code duplicated.
- `<ErrorSummaryComponent>` (concerned with display) has knowledge of the `FieldValidator` class (concerned with logic).
- `needsValidation` is a state variable that's floating at the same level in `props` as the form data fields.  If we can't remove it entirely, I'd like to at least separate it.
- These lines of code are too damn high!  We're pushing 300 lines for a relatively simple three-field form.  How can we reduce vertical scrolling?

**NB - `props` has to be JSON serializable.  Passing objects with methods (e.g. Form fields with validation behaviour) through it requires serializing/deserializing.  There could be dragons this way.**

## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- https://trello.com/b/p2XQo8jN/beacons-beta-private -->

## Things to check

- [ ] Environment variables have been updated
