### PR TITLE
Add primary beacon use page for maritime pleasure use case

### DIFF
--- a/src/components/RadioList.tsx
+++ b/src/components/RadioList.tsx
@@ -11,6 +11,7 @@ interface RadioListItemProps {
   name: string;
   value: string;
   children: ReactNode;
+  inputHtmlAttributes?: Record<string, string>;
 }
 
 interface RadioListItemHintProps {
@@ -19,6 +20,7 @@ interface RadioListItemHintProps {
   value: string;
   children: ReactNode;
   hintText: string;
+  inputHtmlAttributes?: Record<string, string>;
 }
 
 interface RadioListItemConditionalProps {
@@ -38,6 +40,7 @@ export const RadioListItem: FunctionComponent<RadioListItemProps> = ({
   name,
   value,
   children,
+  inputHtmlAttributes = {},
 }: RadioListItemProps): JSX.Element => (
   <div className="govuk-radios__item">
     <input
@@ -46,6 +49,7 @@ export const RadioListItem: FunctionComponent<RadioListItemProps> = ({
       name={name}
       type="radio"
       value={value}
+      {...inputHtmlAttributes}
     />
     <FormLabel className="govuk-radios__label" htmlFor={id}>
       {children}
@@ -59,6 +63,7 @@ export const RadioListItemHint: FunctionComponent<RadioListItemHintProps> = ({
   value,
   children,
   hintText,
+  inputHtmlAttributes = {},
 }: RadioListItemHintProps): JSX.Element => (
   <div className="govuk-radios__item">
     <input
@@ -68,6 +73,7 @@ export const RadioListItemHint: FunctionComponent<RadioListItemHintProps> = ({
       type="radio"
       value={value}
       aria-describedby={`${id}-hint`}
+      {...inputHtmlAttributes}
     />
     <FormLabel className="govuk-radios__label" htmlFor={id}>
       {children}

--- a/src/components/RadioList.tsx
+++ b/src/components/RadioList.tsx
@@ -21,6 +21,11 @@ interface RadioListItemHintProps {
   hintText: string;
 }
 
+interface RadioListItemConditionalProps {
+  id: string;
+  children: ReactNode;
+}
+
 export const RadioList: FunctionComponent<RadioListProps> = ({
   className = "",
   children,
@@ -71,5 +76,17 @@ export const RadioListItemHint: FunctionComponent<RadioListItemHintProps> = ({
     <FormHint forId={id} className="govuk-radios__hint">
       {hintText}
     </FormHint>
+  </div>
+);
+
+export const RadioListItemConditional: FunctionComponent<RadioListItemConditionalProps> = ({
+  id,
+  children,
+}: RadioListItemConditionalProps): JSX.Element => (
+  <div
+    className="govuk-radios__conditional govuk-radios__conditional--hidden"
+    id={id}
+  >
+    {children}
   </div>
 );

--- a/src/components/RadioList.tsx
+++ b/src/components/RadioList.tsx
@@ -10,22 +10,29 @@ interface RadioListItemProps {
   id: string;
   name: string;
   value: string;
-  text: string;
+  children: ReactNode;
 }
 
 interface RadioListItemHintProps {
   id: string;
   name: string;
   value: string;
-  text: string;
+  children: ReactNode;
   hintText: string;
 }
+
+export const RadioList: FunctionComponent<RadioListProps> = ({
+  className = "",
+  children,
+}: RadioListProps): JSX.Element => (
+  <div className={`govuk-radios ${className}`}>{children}</div>
+);
 
 export const RadioListItem: FunctionComponent<RadioListItemProps> = ({
   id,
   name,
   value,
-  text,
+  children,
 }: RadioListItemProps): JSX.Element => (
   <div className="govuk-radios__item">
     <input
@@ -36,7 +43,7 @@ export const RadioListItem: FunctionComponent<RadioListItemProps> = ({
       value={value}
     />
     <FormLabel className="govuk-radios__label" htmlFor={id}>
-      {text}
+      {children}
     </FormLabel>
   </div>
 );
@@ -45,7 +52,7 @@ export const RadioListItemHint: FunctionComponent<RadioListItemHintProps> = ({
   id,
   name,
   value,
-  text,
+  children,
   hintText,
 }: RadioListItemHintProps): JSX.Element => (
   <div className="govuk-radios__item">
@@ -58,18 +65,11 @@ export const RadioListItemHint: FunctionComponent<RadioListItemHintProps> = ({
       aria-describedby={`${id}-hint`}
     />
     <FormLabel className="govuk-radios__label" htmlFor={id}>
-      {text}
+      {children}
     </FormLabel>
 
     <FormHint forId={id} className="govuk-radios__hint">
       {hintText}
     </FormHint>
   </div>
-);
-
-export const RadioList: FunctionComponent<RadioListProps> = ({
-  className = "",
-  children,
-}: RadioListProps): JSX.Element => (
-  <div className={`govuk-radios ${className}`}>{children}</div>
 );

--- a/src/components/RadioList.tsx
+++ b/src/components/RadioList.tsx
@@ -6,6 +6,11 @@ interface RadioListProps {
   children: ReactNode;
 }
 
+interface RadioListConditionalProps {
+  className?: string;
+  children: ReactNode;
+}
+
 interface RadioListItemProps {
   id: string;
   name: string;
@@ -33,6 +38,18 @@ export const RadioList: FunctionComponent<RadioListProps> = ({
   children,
 }: RadioListProps): JSX.Element => (
   <div className={`govuk-radios ${className}`}>{children}</div>
+);
+
+export const RadioListConditional: FunctionComponent<RadioListConditionalProps> = ({
+  className = "",
+  children,
+}: RadioListProps): JSX.Element => (
+  <div
+    className={`govuk-radios govuk-radios--conditional ${className}`}
+    data-module="govuk-radios"
+  >
+    {children}
+  </div>
 );
 
 export const RadioListItem: FunctionComponent<RadioListItemProps> = ({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,7 +11,7 @@ export enum BeaconIntent {
   OTHER = "OTHER",
 }
 
-export enum MaritimeVessel {
+export enum MaritimePleasureVessel {
   MOTOR = "MOTOR",
   SAILING = "SAILING",
   ROWING = "ROWING",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,6 +11,14 @@ export enum BeaconIntent {
   OTHER = "OTHER",
 }
 
+export enum MaritimeVessel {
+  MOTOR = "MOTOR",
+  SAILING = "SAILING",
+  ROWING = "ROWING",
+  SMALL_UNPOWERED = "SMALL_UNPOWERED",
+  OTHER = "OTHER",
+}
+
 export interface Beacon {
   manufacturer: string;
   model: string;

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -19,7 +19,7 @@ import {
   RadioListConditional,
 } from "../../components/RadioList";
 import { withCookieRedirect } from "../../lib/middleware";
-import { MaritimeVessel } from "../../lib/types";
+import { MaritimePleasureVessel } from "../../lib/types";
 
 const PrimaryBeaconUse: FunctionComponent = () => (
   <Layout
@@ -48,15 +48,15 @@ const BeaconUseForm: FunctionComponent = () => (
     <RadioListConditional>
       <RadioListItemHint
         id="motor-vessel"
-        name="use"
-        value={MaritimeVessel.MOTOR}
+        name="maritimePleasureVesselUse"
+        value={MaritimePleasureVessel.MOTOR}
         hintText="E.g. Speedboat, RIB"
       >
         Motor vessel
       </RadioListItemHint>
       <RadioListItemHint
         id="sailing-vessel"
-        name="use"
+        name="maritimePleasureVesselUse"
         value=""
         hintText="E.g. Skiff, Dinghy, Yacht, Catamaran"
       >
@@ -64,24 +64,24 @@ const BeaconUseForm: FunctionComponent = () => (
       </RadioListItemHint>
       <RadioListItemHint
         id="rowing-vessel"
-        name="use"
-        value={MaritimeVessel.SAILING}
+        name="maritimePleasureVesselUse"
+        value={MaritimePleasureVessel.SAILING}
         hintText="E.g. Single person rowing boat, Cornish Gig, Multi-person rowing boat"
       >
         Rowing vessel
       </RadioListItemHint>
       <RadioListItemHint
         id="small-unpowered-vessel"
-        name="use"
-        value={MaritimeVessel.SMALL_UNPOWERED}
-        hintText="E.g. Surfboard, Kitesurfing,  Canoe, Kayak"
+        name="maritimePleasureVesselUse"
+        value={MaritimePleasureVessel.SMALL_UNPOWERED}
+        hintText="E.g. Canoe, Kayak"
       >
         Small unpowered vessel
       </RadioListItemHint>
       <RadioListItem
         id="other-pleasure-vessel"
-        name="use"
-        value={MaritimeVessel.OTHER}
+        name="maritimePleasureVesselUse"
+        value={MaritimePleasureVessel.OTHER}
         inputHtmlAttributes={{
           "data-aria-controls": "conditional-other-pleasure-vessel",
         }}

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -77,7 +77,14 @@ const BeaconUseForm: FunctionComponent = () => (
       >
         Small unpowered vessel
       </RadioListItemHint>
-      <RadioListItem id="other-pleasure-vessel" name="use" value="">
+      <RadioListItem
+        id="other-pleasure-vessel"
+        name="use"
+        value=""
+        inputHtmlAttributes={{
+          "data-aria-controls": "conditional-other-pleasure-vessel",
+        }}
+      >
         Other pleasure vessel
       </RadioListItem>
       <RadioListItemConditional id="conditional-other-pleasure-vessel">

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -13,7 +13,6 @@ import { Grid } from "../../components/Grid";
 import { Layout } from "../../components/Layout";
 import { IfYouNeedHelp } from "../../components/Mca";
 import {
-  RadioList,
   RadioListItemConditional,
   RadioListItem,
   RadioListItemHint,

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -57,7 +57,7 @@ const BeaconUseForm: FunctionComponent = () => (
       <RadioListItemHint
         id="sailing-vessel"
         name="maritimePleasureVesselUse"
-        value=""
+        value={MaritimePleasureVessel.SAILING}
         hintText="E.g. Skiff, Dinghy, Yacht, Catamaran"
       >
         Sailing vessel
@@ -65,7 +65,7 @@ const BeaconUseForm: FunctionComponent = () => (
       <RadioListItemHint
         id="rowing-vessel"
         name="maritimePleasureVesselUse"
-        value={MaritimePleasureVessel.SAILING}
+        value={MaritimePleasureVessel.ROWING}
         hintText="E.g. Single person rowing boat, Cornish Gig, Multi-person rowing boat"
       >
         Rowing vessel

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -1,0 +1,90 @@
+import { GetServerSideProps } from "next";
+import React, { FunctionComponent } from "react";
+import { BackButton, Button } from "../../components/Button";
+import {
+  Form,
+  FormFieldset,
+  FormLegendPageHeading,
+} from "../../components/Form";
+import { Grid } from "../../components/Grid";
+import { Layout } from "../../components/Layout";
+import { IfYouNeedHelp } from "../../components/Mca";
+import { RadioList, RadioListItemHint } from "../../components/RadioList";
+import { withCookieRedirect } from "../../lib/middleware";
+
+const PrimaryBeaconUse: FunctionComponent = () => (
+  <Layout
+    navigation={<BackButton href="/register-a-beacon/beacon-information" />}
+  >
+    <Grid
+      mainContent={
+        <>
+          <BeaconUseForm />
+
+          <IfYouNeedHelp />
+        </>
+      }
+    />
+  </Layout>
+);
+
+const BeaconUseForm: FunctionComponent = () => (
+  <Form action="/register-a-beacon/primary-beacon-use">
+    <FormFieldset>
+      <FormLegendPageHeading>
+        What type of maritime pleasure vessel will you mostly use this beacon
+        on?
+      </FormLegendPageHeading>
+    </FormFieldset>
+
+    <RadioList>
+      <RadioListItemHint
+        id="motor-vessel"
+        name="use"
+        value=""
+        hintText="E.g. Speedboat, RIB"
+      >
+        Motor vessel
+      </RadioListItemHint>
+
+      <RadioListItemHint
+        id="sailing-vessel"
+        name="use"
+        value=""
+        hintText="E.g. Skiff, Dinghy, Yacht, Catamaran"
+      >
+        Sailing vessel
+      </RadioListItemHint>
+
+      <RadioListItemHint
+        id="rowing-vessel"
+        name="use"
+        value=""
+        hintText="E.g. Single person rowing boat, Cornish Gig, Multi-person rowing boat"
+      >
+        Rowing vessel
+      </RadioListItemHint>
+
+      <RadioListItemHint
+        id="other-pleasure-vessel"
+        name="use"
+        value=""
+        hintText="E.g. Surfboard, Kitesurfing,  Canoe, Kayak"
+      >
+        Small unpowered vessel
+      </RadioListItemHint>
+    </RadioList>
+
+    <Button buttonText="Continue" />
+  </Form>
+);
+
+export const getServerSideProps: GetServerSideProps = withCookieRedirect(
+  async () => {
+    return {
+      props: {},
+    };
+  }
+);
+
+export default PrimaryBeaconUse;

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -78,16 +78,17 @@ const BeaconUseForm: FunctionComponent = () => (
       >
         Small unpowered vessel
       </RadioListItemHint>
-      <RadioListItem
+      <RadioListItemHint
         id="other-pleasure-vessel"
         name="maritimePleasureVesselUse"
         value={MaritimePleasureVessel.OTHER}
+        hintText="E.g. Surfboard, Kitesurfing"
         inputHtmlAttributes={{
           "data-aria-controls": "conditional-other-pleasure-vessel",
         }}
       >
         Other pleasure vessel
-      </RadioListItem>
+      </RadioListItemHint>
       <RadioListItemConditional id="conditional-other-pleasure-vessel">
         <FormGroup>
           <FormLabel htmlFor="other-pleasure-vessel-text">

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -19,6 +19,7 @@ import {
   RadioListConditional,
 } from "../../components/RadioList";
 import { withCookieRedirect } from "../../lib/middleware";
+import { MaritimeVessel } from "../../lib/types";
 
 const PrimaryBeaconUse: FunctionComponent = () => (
   <Layout
@@ -48,7 +49,7 @@ const BeaconUseForm: FunctionComponent = () => (
       <RadioListItemHint
         id="motor-vessel"
         name="use"
-        value=""
+        value={MaritimeVessel.MOTOR}
         hintText="E.g. Speedboat, RIB"
       >
         Motor vessel
@@ -64,7 +65,7 @@ const BeaconUseForm: FunctionComponent = () => (
       <RadioListItemHint
         id="rowing-vessel"
         name="use"
-        value=""
+        value={MaritimeVessel.SAILING}
         hintText="E.g. Single person rowing boat, Cornish Gig, Multi-person rowing boat"
       >
         Rowing vessel
@@ -72,7 +73,7 @@ const BeaconUseForm: FunctionComponent = () => (
       <RadioListItemHint
         id="small-unpowered-vessel"
         name="use"
-        value=""
+        value={MaritimeVessel.SMALL_UNPOWERED}
         hintText="E.g. Surfboard, Kitesurfing,  Canoe, Kayak"
       >
         Small unpowered vessel
@@ -80,7 +81,7 @@ const BeaconUseForm: FunctionComponent = () => (
       <RadioListItem
         id="other-pleasure-vessel"
         name="use"
-        value=""
+        value={MaritimeVessel.OTHER}
         inputHtmlAttributes={{
           "data-aria-controls": "conditional-other-pleasure-vessel",
         }}

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -17,6 +17,7 @@ import {
   RadioListItemConditional,
   RadioListItem,
   RadioListItemHint,
+  RadioListConditional,
 } from "../../components/RadioList";
 import { withCookieRedirect } from "../../lib/middleware";
 
@@ -44,7 +45,7 @@ const BeaconUseForm: FunctionComponent = () => (
         on?
       </FormLegendPageHeading>
     </FormFieldset>
-    <RadioList>
+    <RadioListConditional>
       <RadioListItemHint
         id="motor-vessel"
         name="use"
@@ -98,7 +99,7 @@ const BeaconUseForm: FunctionComponent = () => (
           ></Input>
         </FormGroup>
       </RadioListItemConditional>
-    </RadioList>
+    </RadioListConditional>
 
     <Button buttonText="Continue" />
   </Form>

--- a/src/pages/register-a-beacon/primary-beacon-use.tsx
+++ b/src/pages/register-a-beacon/primary-beacon-use.tsx
@@ -4,12 +4,20 @@ import { BackButton, Button } from "../../components/Button";
 import {
   Form,
   FormFieldset,
+  FormGroup,
+  FormLabel,
   FormLegendPageHeading,
+  Input,
 } from "../../components/Form";
 import { Grid } from "../../components/Grid";
 import { Layout } from "../../components/Layout";
 import { IfYouNeedHelp } from "../../components/Mca";
-import { RadioList, RadioListItemHint } from "../../components/RadioList";
+import {
+  RadioList,
+  RadioListItemConditional,
+  RadioListItem,
+  RadioListItemHint,
+} from "../../components/RadioList";
 import { withCookieRedirect } from "../../lib/middleware";
 
 const PrimaryBeaconUse: FunctionComponent = () => (
@@ -36,7 +44,6 @@ const BeaconUseForm: FunctionComponent = () => (
         on?
       </FormLegendPageHeading>
     </FormFieldset>
-
     <RadioList>
       <RadioListItemHint
         id="motor-vessel"
@@ -46,7 +53,6 @@ const BeaconUseForm: FunctionComponent = () => (
       >
         Motor vessel
       </RadioListItemHint>
-
       <RadioListItemHint
         id="sailing-vessel"
         name="use"
@@ -55,7 +61,6 @@ const BeaconUseForm: FunctionComponent = () => (
       >
         Sailing vessel
       </RadioListItemHint>
-
       <RadioListItemHint
         id="rowing-vessel"
         name="use"
@@ -64,15 +69,28 @@ const BeaconUseForm: FunctionComponent = () => (
       >
         Rowing vessel
       </RadioListItemHint>
-
       <RadioListItemHint
-        id="other-pleasure-vessel"
+        id="small-unpowered-vessel"
         name="use"
         value=""
         hintText="E.g. Surfboard, Kitesurfing,  Canoe, Kayak"
       >
         Small unpowered vessel
       </RadioListItemHint>
+      <RadioListItem id="other-pleasure-vessel" name="use" value="">
+        Other pleasure vessel
+      </RadioListItem>
+      <RadioListItemConditional id="conditional-other-pleasure-vessel">
+        <FormGroup>
+          <FormLabel htmlFor="other-pleasure-vessel-text">
+            What sort of vessel is it?
+          </FormLabel>
+          <Input
+            id="other-pleasure-vessel-text"
+            name="other-pleasure-vessel-text"
+          ></Input>
+        </FormGroup>
+      </RadioListItemConditional>
     </RadioList>
 
     <Button buttonText="Continue" />

--- a/test/pages/register-a-beacon/primary-beacon-use.test.tsx
+++ b/test/pages/register-a-beacon/primary-beacon-use.test.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import PrimaryBeaconUse from "../../../src/pages/register-a-beacon/primary-beacon-use";
+
+describe("PrimaryBeaconUse", () => {
+  it("should have a back button which directs the user to the beacon information page", () => {
+    render(<PrimaryBeaconUse />);
+
+    expect(screen.getByText("Back", { exact: true })).toHaveAttribute(
+      "href",
+      "/register-a-beacon/beacon-information"
+    );
+  });
+});

--- a/test/pages/register-a-beacon/primary-beacon-use.test.tsx
+++ b/test/pages/register-a-beacon/primary-beacon-use.test.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import PrimaryBeaconUse from "../../../src/pages/register-a-beacon/primary-beacon-use";
+import PrimaryBeaconUse, {
+  getServerSideProps,
+} from "../../../src/pages/register-a-beacon/primary-beacon-use";
+import { formSubmissionCookieId } from "../../../src/lib/types";
 
 describe("PrimaryBeaconUse", () => {
   it("should have a back button which directs the user to the beacon information page", () => {
@@ -10,5 +13,23 @@ describe("PrimaryBeaconUse", () => {
       "href",
       "/register-a-beacon/beacon-information"
     );
+  });
+
+  describe("getServerSideProps()", () => {
+    let context;
+    beforeEach(() => {
+      context = {
+        req: {
+          cookies: {
+            [formSubmissionCookieId]: "1",
+          },
+        },
+      };
+    });
+
+    it("should return an empty props object", async () => {
+      const expectedProps = await getServerSideProps(context);
+      expect(expectedProps).toStrictEqual({ props: {} });
+    });
   });
 });


### PR DESCRIPTION
## Context

- Add primary beacon use (maritime) inline with the [Miro board](register-a-beacon/primary-beacon-use)
- The page isn't linked up with the `beacon-information` page but this will need to be done once the validation for that page has been done.  @zackads  for awareness
- You can view the page at: http://localhost:3000/register-a-beacon/primary-beacon-use
- The page should still render if JS is disabled.  NOTE: If you disable JS using `npm run dev` then the page is rendered with no CSS.  I have checked serving the app using the built Docker image and this issue is resolved.  Assumed to be down to the differences in the app being served in dev mode vs prod

## Review guide

- [Radio button component](https://design-system.service.gov.uk/components/radios/#conditionally-revealing-content) for conditionally showing the input text
- Separated out `RadioListConditional` and `RadioList` component as just using the one component and inputting properties to determine if it was conditional or not seemed messy and minimal overhead in creating the extra component
- We are currently capturing the third level of maritime uses from the image uploaded.  We will need to capture the top and second level usage but I have not captured an enum for this.  Discussed with @stuart-madetech, but this will be needed for the later pages.  Suggest we create this when we need it.  At this stage of the form the value is not required

## Link to Trello card

- https://trello.com/c/3KJGfjD9/220-maritime-pleasure-page


![image](https://user-images.githubusercontent.com/76042279/108194689-d27fbe00-710e-11eb-838c-f68f3a27e5f8.png)

