### PR TITLE
Organise imports using prettier plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8320,6 +8320,12 @@
       "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true
     },
+    "prettier-plugin-organize-imports": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-1.1.1.tgz",
+      "integrity": "sha512-rFA1lnek1FYkMGthm4xBKME41qUKItTovuo24bCGZu/Vu1n3gW71UPLAkIdwewwkZCe29gRVweSOPXvAdckFuw==",
+      "dev": true
+    },
     "pretty-format": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "lint-staged": "^10.5.4",
     "postcss-normalize": "^9.0.0",
     "prettier": "2.2.1",
+    "prettier-plugin-organize-imports": "^1.1.1",
     "pretty-quick": "^3.1.0",
     "sass": "^1.32.7",
     "ts-node": "^9.1.1",


### PR DESCRIPTION
## Context

- Prettier does not organise imports/remove unused imports as this changes the Abstract Syntax Tree (AST) representation of the code. See: https://prettier.io/docs/en/
- Read the rationale behind the prettier plugin to [organise imports](https://github.com/simonhaenisch/prettier-plugin-organize-imports#rationale)

## Changes in this pull request

- Add prettier plugin for organising imports
- Runs `npm run format` over the code base to organise imports according to the plugin

